### PR TITLE
Fix building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ private void AddEntryToInner(string infile)
 3. Go into `UAssetAPI-master` and run `git checkout be66982`
 4. In `UAssetAPI-master\UAssetAPI\UAssetAPI.csproj`, change `<TargetFrameworkVersion>` to `v4.8`
 5. Open the QueenIO.sln in Visual Studio
+6. In Solution Explorer, right click UAssetAPI > Properties
+7. Set `Target Framework` to `.NET Framework 4.8`
 8. Build the file by right clicking on the solution name in the Solition Explorer
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ private void AddEntryToInner(string infile)
 
 # Dependencies
 - [.NET Framework 4.8](https://dotnet.microsoft.com/download/dotnet-framework)  
-- [UAssetAPI](https://github.com/atenfyr/UAssetAPI) for Building
+- [UAssetAPI](https://github.com/atenfyr/UAssetAPI), commit `be66982` for Building
 - UAsset/UExp Files from Code Vein
 
 # Building
-1. Download both the Source code from QueenIO and [UAssetAPI](https://github.com/atenfyr/UAssetAPI)
+1. Download both the Source code from QueenIO and [UAssetAPI](https://github.com/atenfyr/UAssetAPI) (use UAssetAPI commit `be66982`)
 2. Open the QueenIO.sln in Visual Studio
 3. Fix the UAssetAPI reference to where you unpack it if need be
 4. Build the file by right clicking on the solution name in the Solition Explorer

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ private void AddEntryToInner(string infile)
 - UAsset/UExp Files from Code Vein
 
 # Building
-1. Download both the Source code from QueenIO and [UAssetAPI](https://github.com/atenfyr/UAssetAPI) (make sure to `git checkout be66982` in the UAssetAPI repository)
-2. Open the QueenIO.sln in Visual Studio
-3. Rename the cloned `UAssetAPI` repository to `UAssetAPI-master` and put it under `C:\Programs`. Or, fix the UAssetAPI reference to where you unpack it
+1. Download both the Source code from QueenIO and [UAssetAPI](https://github.com/atenfyr/UAssetAPI)
+2. Move UAssetAPI folder into `C:\Programs` and rename it `UAssetAPI-master`. Or fix the UAssetAPI reference to where you unpack it in Visual Studio, in later steps
+3. Go into `UAssetAPI-master` and run `git checkout be66982`
 4. In `UAssetAPI-master\UAssetAPI\UAssetAPI.csproj`, change `<TargetFrameworkVersion>` to `v4.8`
-5. Build the file by right clicking on the solution name in the Solition Explorer
+5. Open the QueenIO.sln in Visual Studio
+8. Build the file by right clicking on the solution name in the Solition Explorer
 
 # Credits
 [UAssetAPI](https://github.com/atenfyr/UAssetAPI) Really the Back bone to the whole thing by providing an easy to use uasset phraser.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ private void AddEntryToInner(string infile)
 - UAsset/UExp Files from Code Vein
 
 # Building
-1. Download both the Source code from QueenIO and [UAssetAPI](https://github.com/atenfyr/UAssetAPI) (use UAssetAPI commit `be66982`)
+1. Download both the Source code from QueenIO and [UAssetAPI](https://github.com/atenfyr/UAssetAPI) (make sure to `git checkout be66982` in the UAssetAPI repository)
 2. Open the QueenIO.sln in Visual Studio
 3. Rename the cloned `UAssetAPI` repository to `UAssetAPI-master` and put it under `C:\Programs`. Or, fix the UAssetAPI reference to where you unpack it
 4. In `UAssetAPI-master\UAssetAPI\UAssetAPI.csproj`, change `<TargetFrameworkVersion>` to `v4.8`

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ private void AddEntryToInner(string infile)
 # Building
 1. Download both the Source code from QueenIO and [UAssetAPI](https://github.com/atenfyr/UAssetAPI) (use UAssetAPI commit `be66982`)
 2. Open the QueenIO.sln in Visual Studio
-3. Fix the UAssetAPI reference to where you unpack it if need be
-4. Build the file by right clicking on the solution name in the Solition Explorer
+3. Rename the cloned `UAssetAPI` repository to `UAssetAPI-master` and put it under `C:\Programs`. Or, fix the UAssetAPI reference to where you unpack it
+4. In `UAssetAPI-master\UAssetAPI\UAssetAPI.csproj`, change `<TargetFrameworkVersion>` to `v4.8`
+5. Build the file by right clicking on the solution name in the Solition Explorer
 
 # Credits
 [UAssetAPI](https://github.com/atenfyr/UAssetAPI) Really the Back bone to the whole thing by providing an easy to use uasset phraser.


### PR DESCRIPTION
Build instructions were outdated and did not work for me. To fix it, I used a specific version of UAssetAPI, a specific version of .NET and moved the repository to the hardcoded path, `C:\Programs\UAssetAPI-master`.